### PR TITLE
feat: deploy to docker hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+# This workflow deploys the production Docker image to Docker Hub
+
+name: Publish to Docker Hub
+
+on:
+  push:
+    branches-ignore:
+      - 'main'
+  release:
+    # types: [published]
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: weaponsforge/gemini-cli
+
+jobs:
+  docker-build-push:
+    name: Build and Push Docker Image
+    # if: github.event.release.target_commitish == 'master' && vars.DOCKERHUB_USERNAME != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,8 @@
 name: Publish to Docker Hub
 
 on:
-  push:
-    branches-ignore:
-      - 'main'
   release:
-    # types: [published]
+    types: [published]
 
 env:
   REGISTRY: docker.io
@@ -16,7 +13,7 @@ env:
 jobs:
   docker-build-push:
     name: Build and Push Docker Image
-    # if: github.event.release.target_commitish == 'master' && vars.DOCKERHUB_USERNAME != ''
+    if: github.event.release.target_commitish == 'master' && vars.DOCKERHUB_USERNAME != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,7 +61,7 @@ jobs:
             BUILDKIT_INLINE_CACHE=1
 
       - name: Scan image for vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           format: 'sarif'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains Docker files and recommended configurations for a quick
 2. Docker
    - Windows OS (Docker Desktop): Docker version 27.4.0, build bde2b89
    - Linux/Mac OS: _(applicable Docker versions)_
-  
+
 
 Demo
 
@@ -31,9 +31,14 @@ https://github.com/user-attachments/assets/7e7edb8c-3b97-4933-b2a6-14c48e54c0c7
    - See  the [projects/README.md](projects/README.md) file for more details on organizing your project repositories.
    - **INFO:** this step is optional since the Gemini CLI does not require code repositories to answer general prompts.
 
-4. Build the Docker image.
+4. **Local build:** build the Docker image.
    - Run this command only during the **initial installation** or if there are **changes to the `Dockerfile`**.<br>
    - `docker compose build`
+
+5. **Pull the pre-built Docker image**: (Optional) This repository deploys the "latest" Docker image to Docker Hub on the creation of new Release/Tags. It is available at: https://hub.docker.com/r/weaponsforge/gemini-cli
+   - Use this step to skip building the image locally at **step # 4**.
+   - Pull the pre-built development Docker image:
+      `docker pull weaponsforge/gemini-cli`
 
 ## 📖 Usage
 


### PR DESCRIPTION
- Deploy the image to Docker Hub on create of new tags/releases
- Docker Hub URL is available at: https://hub.docker.com/r/weaponsforge/gemini-cli
- Use BuildX and scan image during deployment
- Update README