### PR TITLE
fix/weaponsforge-1: add permissions writing to gh security tab

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
       packages: write
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
- Fix: uploading security reports in GH security tab - add security write permission in job